### PR TITLE
Updates for Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ license = "MIT"
 name = "bevy_normal_material"
 readme = "README.md"
 repository = "https://github.com/mattatz/bevy_normal_material"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies.bevy]
 default-features = false
 features = ["bevy_render", "bevy_pbr", "bevy_asset"]
-version = "0.10"
+version = "0.11"
 
 [dev-dependencies.bevy]
 default-features = false
 features = ["bevy_render", "bevy_pbr", "bevy_core_pipeline", "bevy_asset"]
-version = "0.10"
+version = "0.11"
 
 [features]
 "examples" = ["bevy/bevy_render", "bevy/bevy_pbr", "bevy/bevy_core_pipeline", "bevy/bevy_winit", "bevy/x11"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use bevy_normal_material::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugin(NormalMaterialPlugin);
+        .add_plugins(NormalMaterialPlugin);
 }
 ```
 
@@ -45,3 +45,4 @@ fn setup(
 | ---- | ------------- |
 | 0.9  | 0.1           |
 | 0.10  | 0.2           |
+| 0.11  | 0.3           |

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -1,9 +1,8 @@
 use bevy::{
     prelude::{
         shape, App, Assets, Camera3dBundle, ClearColor, Color, Commands, MaterialMeshBundle, Mesh,
-        ResMut, Transform, Vec3,
+        ResMut, Transform, Vec3, Startup,
     },
-    render::render_resource::{Face, FrontFace},
     DefaultPlugins,
 };
 use bevy_normal_material::prelude::*;
@@ -11,9 +10,9 @@ use bevy_normal_material::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(NormalMaterialPlugin)
+        .add_plugins(NormalMaterialPlugin)
         .insert_resource(ClearColor(Color::rgb(0.01, 0.02, 0.08)))
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::{
         shape, AlphaMode, App, Assets, Camera3dBundle, ClearColor, Color, Commands,
-        MaterialMeshBundle, Mesh, ResMut, Transform, Vec3,
+        MaterialMeshBundle, Mesh, ResMut, Transform, Vec3, Startup,
     },
     DefaultPlugins,
 };
@@ -10,9 +10,9 @@ use bevy_normal_material::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(NormalMaterialPlugin)
+        .add_plugins(NormalMaterialPlugin)
         .insert_resource(ClearColor(Color::rgb(0.01, 0.02, 0.08)))
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,12 +1,12 @@
 use bevy::{
     prelude::{AlphaMode, Material},
-    reflect::TypeUuid,
+    reflect::{TypeUuid, TypePath},
     render::render_resource::{AsBindGroup, Face},
 };
 
 use crate::SHADER_HANDLE;
 
-#[derive(AsBindGroup, TypeUuid, Clone, Copy)]
+#[derive(AsBindGroup, TypeUuid, Clone, Copy, TypePath)]
 #[uuid = "cd561053-324b-4f72-a486-422320cd7ac2"]
 #[bind_group_data(NormalMaterialKey)]
 pub struct NormalMaterial {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -9,8 +9,8 @@ impl Plugin for NormalMaterialPlugin {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             SHADER_HANDLE,
-            Shader::from_wgsl(include_str!("./shaders/normal.wgsl")),
+            Shader::from_wgsl(include_str!("./shaders/normal.wgsl"), "./shaders/normal.wgsl"),
         );
-        app.add_plugin(MaterialPlugin::<NormalMaterial>::default());
+        app.add_plugins(MaterialPlugin::<NormalMaterial>::default());
     }
 }

--- a/src/shaders/normal.wgsl
+++ b/src/shaders/normal.wgsl
@@ -8,8 +8,9 @@ var<uniform> material: NormalMaterial;
 
 @fragment
 fn fragment(
-    #import bevy_pbr::mesh_vertex_output
+    #import bevy_pbr::mesh_vertex_output MeshVertexOutput
+    mesh: MeshVertexOutput,
 ) -> @location(0) vec4<f32> {
-    var nn = (world_normal + 1.0) * 0.5;
+    var nn = (mesh.world_normal + 1.0) * 0.5;
     return vec4(nn, material.opacity);
 }


### PR DESCRIPTION
Updates for Bevy 0.11:
 - Derive `TypePath` for `NormalMaterial`
 - Misc function call updates
 - Update normal.wgsl shader

See https://bevyengine.org/learn/migration-guides/0.10-0.11/#improve-shader-import-model for some context on normal.wgsl change.