### PR TITLE
Upgrade to Bevy 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /target
 .DS_Store
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,20 +11,20 @@ license = "MIT"
 name = "bevy_normal_material"
 readme = "README.md"
 repository = "https://github.com/mattatz/bevy_normal_material"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies.bevy]
 default-features = false
 features = ["bevy_render", "bevy_pbr", "bevy_asset", "tonemapping_luts"]
-version = "0.14.2"
+version = "0.15.0"
 
 [dev-dependencies.bevy]
 default-features = false
 features = ["bevy_render", "bevy_pbr", "bevy_core_pipeline", "bevy_asset"]
-version = "0.14.2"
+version = "0.15.0"
 
 [features]
-examples = ["bevy/bevy_render", "bevy/bevy_pbr", "bevy/bevy_core_pipeline", "bevy/bevy_winit", "bevy/x11"]
+examples = ["bevy/bevy_render", "bevy/bevy_pbr", "bevy/bevy_core_pipeline", "bevy/bevy_winit", "bevy/x11", "bevy/bevy_window"]
 webgl = []
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<NormalMaterial>>,
 ) {
-    commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(NormalMaterial::default()),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(NormalMaterial::default())),
+    ));
 }
 ```
 
 ## Compatibility
 
 | bevy | bevy_normal_material |
-| ---- | ------------- |
-| 0.9  | 0.1           |
-| 0.10  | 0.2           |
-| 0.11  | 0.3           |
-| 0.12  | 0.4           |
-| 0.13  | 0.5           |
-| 0.14  | 0.6           |
+|------|----------------------|
+| 0.9  | 0.1                  |
+| 0.10 | 0.2                  |
+| 0.11 | 0.3                  |
+| 0.12 | 0.4                  |
+| 0.13 | 0.5                  |
+| 0.14 | 0.6                  |
+| 0.15 | 0.7                  |

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -1,11 +1,8 @@
-use bevy::{
-    math::primitives::Cuboid,
-    prelude::{
-        App, Assets, Camera3dBundle, ClearColor, Color, Commands, MaterialMeshBundle, Mesh, ResMut,
-        Startup, Transform, Vec3,
-    },
-    DefaultPlugins,
-};
+use bevy::prelude::{Camera3d, Cuboid, Mesh3d, MeshMaterial3d};
+use bevy::{prelude::{
+    App, Assets, ClearColor, Color, Commands, Mesh, ResMut,
+    Startup, Transform, Vec3,
+}, DefaultPlugins};
 use bevy_normal_material::prelude::*;
 
 fn main() {
@@ -22,15 +19,14 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<NormalMaterial>>,
 ) {
-    commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(Cuboid::default())),
-        transform: Transform::from_xyz(0.0, 0.25, 0.0),
-        material: materials.add(NormalMaterial::default()),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(NormalMaterial::default())),
+        Transform::from_xyz(0.0, 0.25, 0.0)
+    ));
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,8 +1,9 @@
+use bevy::pbr::MeshMaterial3d;
+use bevy::prelude::{Camera3d, Mesh3d};
 use bevy::{
     math::primitives::Cuboid,
     prelude::{
-        AlphaMode, App, Assets, Camera3dBundle, ClearColor, Color, Commands, MaterialMeshBundle,
-        Mesh, ResMut, Startup, Transform, Vec3,
+        AlphaMode, App, Assets, ClearColor, Color, Commands, Mesh, ResMut, Startup, Transform, Vec3,
     },
     DefaultPlugins,
 };
@@ -22,20 +23,19 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<NormalMaterial>>,
 ) {
-    commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(Cuboid::default())),
-        transform: Transform::from_xyz(0.0, 0.25, 0.0),
-        material: materials.add(NormalMaterial {
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(NormalMaterial {
             opacity: 0.5,
             alpha_mode: AlphaMode::Blend,
             cull_mode: None,
             ..Default::default()
-        }),
-        ..Default::default()
-    });
+        })),
+        Transform::from_xyz(0.0, 0.25, 0.0),
+    ));
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }


### PR DESCRIPTION
* In examples, replace deprecated MaterialMeshBundle with Mesh3d and MeshMaterial3d.
* Update readme example to use Cuboid instead of shape::Cube for consistency. Also replace MaterialMeshBundle.
* In examples, replace deprecated Camera3dBundle with Camera3d